### PR TITLE
Add possibility to retrieve payload of faulty HTTP response

### DIFF
--- a/src/Kralizek.Extensions.Http.Json/HttpRestClient.cs
+++ b/src/Kralizek.Extensions.Http.Json/HttpRestClient.cs
@@ -52,6 +52,16 @@ namespace Kralizek.Extensions.Http
             return _httpFactory.CreateClient();
         }
 
+        private static async Task<string?> GetContentAsString(HttpContent content)
+        {
+            if (content is null)
+            {
+                return null;
+            }
+
+            return await content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
         #region Send
 #pragma warning disable CA2000 // Dispose objects before losing scope. Justification: False positive, see https://github.com/dotnet/roslyn-analyzers/issues/3042
 
@@ -77,7 +87,7 @@ namespace Kralizek.Extensions.Http
 
             if (response is { IsSuccessStatusCode: true })
             {
-                var incomingContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
 
                 var result = JsonConvert.DeserializeObject<TResult>(incomingContent, _options.SerializerSettings);
 
@@ -85,7 +95,9 @@ namespace Kralizek.Extensions.Http
             }
             else
             {
-                throw new HttpException(response.StatusCode, response.ReasonPhrase);
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
+
+                throw new HttpException(response.StatusCode, response.ReasonPhrase) { Payload = incomingContent };
             }
         }
 
@@ -108,7 +120,7 @@ namespace Kralizek.Extensions.Http
 
             if (response is { IsSuccessStatusCode: true })
             {
-                var incomingContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
 
                 var result = JsonConvert.DeserializeObject<TResult>(incomingContent, _options.SerializerSettings);
 
@@ -116,7 +128,9 @@ namespace Kralizek.Extensions.Http
             }
             else
             {
-                throw new HttpException(response.StatusCode, response.ReasonPhrase);
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
+
+                throw new HttpException(response.StatusCode, response.ReasonPhrase) { Payload = incomingContent };
             }
         }
 
@@ -141,7 +155,9 @@ namespace Kralizek.Extensions.Http
 
             if (response is { IsSuccessStatusCode: false })
             {
-                throw new HttpException(response.StatusCode, response.ReasonPhrase);
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
+
+                throw new HttpException(response.StatusCode, response.ReasonPhrase) { Payload = incomingContent };
             }
         }
 
@@ -160,7 +176,9 @@ namespace Kralizek.Extensions.Http
 
             if (response is { IsSuccessStatusCode: false })
             {
-                throw new HttpException(response.StatusCode, response.ReasonPhrase);
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
+
+                throw new HttpException(response.StatusCode, response.ReasonPhrase) { Payload = incomingContent };
             }
         }
 

--- a/src/Kralizek.Extensions.Http/HttpException.cs
+++ b/src/Kralizek.Extensions.Http/HttpException.cs
@@ -90,5 +90,10 @@ namespace Kralizek.Extensions.Http
         /// The reason phrase returned from the server.
         /// </summary>
         public string? ReasonPhrase { get; set; }
+
+        /// <summary>
+        /// The payload attached to the faulty HTTP response.
+        /// </summary>
+        public string? Payload { get; set; }
     }
 }

--- a/tests/Tests.Extensions.Http/HttpRestClientTests.cs
+++ b/tests/Tests.Extensions.Http/HttpRestClientTests.cs
@@ -25,7 +25,7 @@ namespace Tests.Extensions.Http
         [InlineCustomAutoData("POST")]
         [InlineCustomAutoData("PUT")]
         [InlineCustomAutoData("DELETE")]
-        public async Task SendAsync_can_send_request_with_body_and_receive_response_with_body(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request, Response response)
+        public async Task SendAsync_with_Request_and_Response_can_send_request_with_body_and_receive_response_with_body(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request, Response response)
         {
             var httpMethod = new HttpMethod(method);
 
@@ -43,13 +43,13 @@ namespace Tests.Extensions.Http
         [InlineCustomAutoData("POST")]
         [InlineCustomAutoData("PUT")]
         [InlineCustomAutoData("DELETE")]
-        public void SendAsync_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request, Response response)
+        public void SendAsync_with_Request_and_Response_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request)
         {
             var httpMethod = new HttpMethod(method);
 
             handler.When(httpMethod, uri.ToString())
                     .WithJsonContent(request)
-                    .Respond(HttpStatusCode.NotFound, JsonContent.FromObject(response));
+                    .Respond(HttpStatusCode.NotFound);
 
             Assert.That(() => sut.SendAsync<Request, Response>(httpMethod, uri.ToString(), request), Throws.TypeOf<HttpException>());
         }
@@ -59,7 +59,23 @@ namespace Tests.Extensions.Http
         [InlineCustomAutoData("POST")]
         [InlineCustomAutoData("PUT")]
         [InlineCustomAutoData("DELETE")]
-        public void SendAsync_can_send_request_with_body_and_receive_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request)
+        public void SendAsync_with_Request_and_Response_attaches_error_payload_to_exception_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request, string errorPayload)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithJsonContent(request)
+                    .Respond(HttpStatusCode.NotFound, "text/plain", errorPayload);
+
+            Assert.That(() => sut.SendAsync<Request, Response>(httpMethod, uri.ToString(), request), Throws.TypeOf<HttpException>().And.Property(nameof(HttpException.Payload)).EqualTo(errorPayload));
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_with_Request_can_send_request_with_body_and_receive_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request)
         {
             var httpMethod = new HttpMethod(method);
 
@@ -67,7 +83,7 @@ namespace Tests.Extensions.Http
                     .WithJsonContent(request)
                     .Respond(HttpStatusCode.OK);
 
-            Assert.That(() => sut.SendAsync(httpMethod, uri.ToString(), request), Throws.Nothing);
+            Assert.That(() => sut.SendAsync<Request>(httpMethod, uri.ToString(), request), Throws.Nothing);
         }
 
         [Test]
@@ -75,7 +91,7 @@ namespace Tests.Extensions.Http
         [InlineCustomAutoData("POST")]
         [InlineCustomAutoData("PUT")]
         [InlineCustomAutoData("DELETE")]
-        public void SendAsync_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request)
+        public void SendAsync_with_Request_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request)
         {
             var httpMethod = new HttpMethod(method);
 
@@ -83,7 +99,7 @@ namespace Tests.Extensions.Http
                     .WithJsonContent(request)
                     .Respond(HttpStatusCode.NotFound);
 
-            Assert.That(() => sut.SendAsync(httpMethod, uri.ToString(), request), Throws.TypeOf<HttpException>());
+            Assert.That(() => sut.SendAsync<Request>(httpMethod, uri.ToString(), request), Throws.TypeOf<HttpException>());
         }
 
         [Test]
@@ -91,7 +107,23 @@ namespace Tests.Extensions.Http
         [InlineCustomAutoData("POST")]
         [InlineCustomAutoData("PUT")]
         [InlineCustomAutoData("DELETE")]
-        public async Task SendAsync_can_send_request_and_receive_response_with_body(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Response response)
+        public void SendAsync_with_Request_attaches_error_payload_to_exception_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request, string errorPayload)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithJsonContent(request)
+                    .Respond(HttpStatusCode.NotFound, "text/plain", errorPayload);
+
+            Assert.That(() => sut.SendAsync<Request>(httpMethod, uri.ToString(), request), Throws.TypeOf<HttpException>().And.Property(nameof(HttpException.Payload)).EqualTo(errorPayload));
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public async Task SendAsync_with_Response_can_send_request_and_receive_response_with_body(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Response response)
         {
             var httpMethod = new HttpMethod(method);
 
@@ -108,14 +140,29 @@ namespace Tests.Extensions.Http
         [InlineCustomAutoData("POST")]
         [InlineCustomAutoData("PUT")]
         [InlineCustomAutoData("DELETE")]
-        public void SendAsync_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Response response)
+        public void SendAsync_with_Response_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri)
         {
             var httpMethod = new HttpMethod(method);
 
             handler.When(httpMethod, uri.ToString())
-                    .Respond(HttpStatusCode.NotFound, JsonContent.FromObject(response));
+                    .Respond(HttpStatusCode.NotFound);
 
             Assert.That(() => sut.SendAsync<Response>(httpMethod, uri.ToString()), Throws.TypeOf<HttpException>());
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_with_Response_attaches_error_payload_to_exception_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string errorPayload)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .Respond(HttpStatusCode.NotFound, "text/plain", errorPayload);
+
+            Assert.That(() => sut.SendAsync<Response>(httpMethod, uri.ToString()), Throws.TypeOf<HttpException>().And.Property(nameof(HttpException.Payload)).EqualTo(errorPayload));
         }
 
         [Test]
@@ -145,7 +192,22 @@ namespace Tests.Extensions.Http
             handler.When(httpMethod, uri.ToString())
                     .Respond(HttpStatusCode.NotFound);
 
-            Assert.That(() => sut.SendAsync<Response>(httpMethod, uri.ToString()), Throws.TypeOf<HttpException>());
+            Assert.That(() => sut.SendAsync(httpMethod, uri.ToString()), Throws.TypeOf<HttpException>());
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_attaches_error_payload_to_exception_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string errorPayload)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .Respond(HttpStatusCode.NotFound, "text/plain", errorPayload);
+
+            Assert.That(() => sut.SendAsync(httpMethod, uri.ToString()), Throws.TypeOf<HttpException>().And.Property(nameof(HttpException.Payload)).EqualTo(errorPayload));
         }
 
         [Test]


### PR DESCRIPTION
Currently, when the HTTP response is non successful, its payload is lost.

This PR fixes it by adding an extra field to the `HttpException` so that library users can access the payload.