### PR TITLE
Added support for HttpContent

### DIFF
--- a/src/Kralizek.Extensions.Http.Json/HttpRestClient.cs
+++ b/src/Kralizek.Extensions.Http.Json/HttpRestClient.cs
@@ -62,6 +62,9 @@ namespace Kralizek.Extensions.Http
             return await content.ReadAsStringAsync().ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
+        public HttpClient HttpClient => CreateClient();
+
         #region Send
 #pragma warning disable CA2000 // Dispose objects before losing scope. Justification: False positive, see https://github.com/dotnet/roslyn-analyzers/issues/3042
 
@@ -73,8 +76,46 @@ namespace Kralizek.Extensions.Http
         /// <inheritdoc/>
         public async Task<TResult> SendAsync<TContent, TResult>(HttpMethod method, string path, TContent content, IQueryString? query = null)
         {
-            var httpContent = JsonContent.FromObject(content, _options.Encoding, _options.ContentMediaType, _options.SerializerSettings);
+            var httpContent = content switch
+            {
+                HttpContent http => http,
+                _ => JsonContent.FromObject(content, _options.Encoding, _options.ContentMediaType, _options.SerializerSettings),
+            };
 
+            var requestUrl = ComposeUrl(path, query);
+
+            using var request = new HttpRequestMessage(method, requestUrl) { Content = httpContent };
+
+            await LogRequest(request, includeContent: true).ConfigureAwait(false);
+
+            using var response = await CreateClient().SendAsync(request).ConfigureAwait(false);
+
+            await LogResponse(response).ConfigureAwait(false);
+
+            if (response is { IsSuccessStatusCode: true })
+            {
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
+
+                var result = JsonConvert.DeserializeObject<TResult>(incomingContent, _options.SerializerSettings);
+
+                return result;
+            }
+            else
+            {
+                var incomingContent = await GetContentAsString(response.Content).ConfigureAwait(false);
+
+                throw new HttpException(response.StatusCode, response.ReasonPhrase) { Payload = incomingContent };
+            }
+        }
+
+        /// <summary>
+        /// Sends an HTTP request with a generic <see cref="HttpContent" /> payload and receives a response with payload of type <typeparamref name="TResult"/>.
+        /// The request payload is sent as-is.
+        /// The response payload is assumed to be JSON.
+        /// </summary>
+        /// <inheritdoc />
+        public async Task<TResult> SendAsync<TResult>(HttpMethod method, string path, HttpContent httpContent, IQueryString? query = null)
+        {
             var requestUrl = ComposeUrl(path, query);
 
             using var request = new HttpRequestMessage(method, requestUrl) { Content = httpContent };
@@ -141,7 +182,11 @@ namespace Kralizek.Extensions.Http
         /// <inheritdoc/>
         public async Task SendAsync<TContent>(HttpMethod method, string path, TContent content, IQueryString? query = null)
         {
-            var httpContent = JsonContent.FromObject(content, _options.Encoding, _options.ContentMediaType, _options.SerializerSettings);
+            var httpContent = content switch
+            {
+                HttpContent http => http,
+                _ => JsonContent.FromObject(content, _options.Encoding, _options.ContentMediaType, _options.SerializerSettings),
+            };
 
             var requestUrl = ComposeUrl(path, query);
 

--- a/src/Kralizek.Extensions.Http.Json/IHttpRestClient.cs
+++ b/src/Kralizek.Extensions.Http.Json/IHttpRestClient.cs
@@ -22,6 +22,17 @@ namespace Kralizek.Extensions.Http
         Task<TResult> SendAsync<TContent, TResult>(HttpMethod method, string path, TContent content, IQueryString? query = null);
 
         /// <summary>
+        /// Sends an HTTP request with a generic <see cref="HttpContent" /> payload and receives a response with payload of type <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <param name="method">The HTTP method of the request.</param>
+        /// <param name="path">The path to be requested.</param>
+        /// <param name="httpContent">The payload of the request.</param>
+        /// <param name="query">The querystring of the request.</param>
+        /// <typeparam name="TResult">The type to deserialize the response into.</typeparam>
+        /// <returns>If successful, it returns an instance of <typeparamref name="TResult"/>, otherwise it throws a <see cref="HttpException"/>.</returns>
+        Task<TResult> SendAsync<TResult>(HttpMethod method, string path, HttpContent httpContent, IQueryString? query = null);
+
+        /// <summary>
         /// Sends an HTTP request and receives a response with payload of type <typeparamref name="TResult"/>.
         /// </summary>
         /// <param name="method">The HTTP method of the request.</param>
@@ -50,5 +61,10 @@ namespace Kralizek.Extensions.Http
         /// <param name="query">The querystring of the request.</param>
         /// <returns>If unsuccessful, it throws a <see cref="HttpException"/>.</returns>
         Task SendAsync(HttpMethod method, string path, IQueryString? query = null);
+
+        /// <summary>
+        /// Returns the underlying <see cref="HttpClient" />.
+        /// </summary>
+        HttpClient HttpClient { get; }
     }
 }

--- a/src/Kralizek.Extensions.Http.Json/Kralizek.Extensions.Http.Json.csproj
+++ b/src/Kralizek.Extensions.Http.Json/Kralizek.Extensions.Http.Json.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Kralizek.Extensions.Http.Json</AssemblyName>
     <Description>Classes and extension methods to make easier to work with JSON APIs via HttpClient</Description>
     <PackageTags>dotnet-standard;http-client;querystring;rest-client</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Kralizek.Extensions.Http.Json/Kralizek.Extensions.Http.Json.csproj
+++ b/src/Kralizek.Extensions.Http.Json/Kralizek.Extensions.Http.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net471;net5.0</TargetFrameworks>
     <PackageId>Kralizek.Extensions.Http.Json</PackageId>
     <AssemblyName>Kralizek.Extensions.Http.Json</AssemblyName>
     <Description>Classes and extension methods to make easier to work with JSON APIs via HttpClient</Description>

--- a/src/Kralizek.Extensions.Http/Kralizek.Extensions.Http.csproj
+++ b/src/Kralizek.Extensions.Http/Kralizek.Extensions.Http.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Kralizek.Extensions.Http</AssemblyName>
     <Description>Classes and extension methods to make easier to work with REST APIs via HttpClient</Description>
     <PackageTags>dotnet-standard;http-client;querystring;</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Kralizek.Extensions.Http/Kralizek.Extensions.Http.csproj
+++ b/src/Kralizek.Extensions.Http/Kralizek.Extensions.Http.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net471;net5.0</TargetFrameworks>
     <PackageId>Kralizek.Extensions.Http</PackageId>
     <AssemblyName>Kralizek.Extensions.Http</AssemblyName>
     <Description>Classes and extension methods to make easier to work with REST APIs via HttpClient</Description>

--- a/tests/Tests.Extensions.Http/HttpRestClientTests.cs
+++ b/tests/Tests.Extensions.Http/HttpRestClientTests.cs
@@ -75,6 +75,62 @@ namespace Tests.Extensions.Http
         [InlineCustomAutoData("POST")]
         [InlineCustomAutoData("PUT")]
         [InlineCustomAutoData("DELETE")]
+        public async Task SendAsync_with_HttpContent_and_Response_can_send_request_with_body_and_receive_response_with_body(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string content, Response response)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithContent(content)
+                    .Respond(HttpStatusCode.OK, JsonContent.FromObject(response));
+
+            var httpContent = new StringContent(content);
+
+            var actualResponse = await sut.SendAsync<Response>(httpMethod, uri.ToString(), httpContent);
+
+            Assert.That(actualResponse, Is.EqualTo(response));
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_with_HttpContent_and_Response_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string content)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithContent(content)
+                    .Respond(HttpStatusCode.NotFound);
+
+            var httpContent = new StringContent(content);
+
+            Assert.That(() => sut.SendAsync<Response>(httpMethod, uri.ToString(), httpContent), Throws.TypeOf<HttpException>());
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_with_HttpContent_and_Response_attaches_error_payload_to_exception_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string content, string errorPayload)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithContent(content)
+                    .Respond(HttpStatusCode.NotFound, "text/plain", errorPayload);
+
+            var httpContent = new StringContent(content);
+
+            Assert.That(() => sut.SendAsync<Response>(httpMethod, uri.ToString(), httpContent), Throws.TypeOf<HttpException>().And.Property(nameof(HttpException.Payload)).EqualTo(errorPayload));
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
         public void SendAsync_with_Request_can_send_request_with_body_and_receive_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, Request request)
         {
             var httpMethod = new HttpMethod(method);
@@ -116,6 +172,60 @@ namespace Tests.Extensions.Http
                     .Respond(HttpStatusCode.NotFound, "text/plain", errorPayload);
 
             Assert.That(() => sut.SendAsync<Request>(httpMethod, uri.ToString(), request), Throws.TypeOf<HttpException>().And.Property(nameof(HttpException.Payload)).EqualTo(errorPayload));
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_with_HttpContent_can_send_request_with_body_and_receive_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string content)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithContent(content)
+                    .Respond(HttpStatusCode.OK);
+
+            var httpContent = new StringContent(content);
+
+            Assert.That(() => sut.SendAsync(httpMethod, uri.ToString(), httpContent), Throws.Nothing);
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_with_HttpContent_throws_HttpException_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string content)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithContent(content)
+                    .Respond(HttpStatusCode.NotFound);
+
+            var httpContent = new StringContent(content);
+
+            Assert.That(() => sut.SendAsync(httpMethod, uri.ToString(), httpContent), Throws.TypeOf<HttpException>());
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void SendAsync_with_HttpContent_attaches_error_payload_to_exception_if_nonSuccessful_response(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri, string content, string errorPayload)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            handler.When(httpMethod, uri.ToString())
+                    .WithContent(content)
+                    .Respond(HttpStatusCode.NotFound, "text/plain", errorPayload);
+
+            var httpContent = new StringContent(content);
+
+            Assert.That(() => sut.SendAsync(httpMethod, uri.ToString(), httpContent), Throws.TypeOf<HttpException>().And.Property(nameof(HttpException.Payload)).EqualTo(errorPayload));
         }
 
         [Test]
@@ -227,6 +337,25 @@ namespace Tests.Extensions.Http
             await sut.SendAsync(httpMethod, uri.ToString());
 
             Mock.Get(httpClientFactory).Verify(p => p.CreateClient(httpClientName), Times.AtLeastOnce());
+        }
+
+        [Test]
+        [InlineCustomAutoData("GET")]
+        [InlineCustomAutoData("POST")]
+        [InlineCustomAutoData("PUT")]
+        [InlineCustomAutoData("DELETE")]
+        public void HttpClient_returns_an_instance_of_HttpClient_configured(string method, [Frozen] MockHttpMessageHandler handler, HttpRestClient sut, Uri uri)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            using var httpRequest = new HttpRequestMessage(httpMethod, uri);
+
+            handler.When(httpMethod, uri.ToString())
+                    .Respond(HttpStatusCode.OK);
+
+            var httpClient = sut.HttpClient;
+
+            Assert.That(() => httpClient.SendAsync(httpRequest), Throws.Nothing);
         }
     }
 }

--- a/tests/Tests.Extensions.Http/Tests.Extensions.Http.csproj
+++ b/tests/Tests.Extensions.Http/Tests.Extensions.Http.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;netcoreapp2.1;net5.0</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request adds support so that when an HttpContent is passed as payload, it doesn't get serialized but gets added as is.